### PR TITLE
fix(ci): correct path rewriting logic in release package script

### DIFF
--- a/.github/workflows/scripts/create-release-packages.sh
+++ b/.github/workflows/scripts/create-release-packages.sh
@@ -31,11 +31,13 @@ mkdir -p "$GENRELEASES_DIR"
 rm -rf "$GENRELEASES_DIR"/* || true
 
 rewrite_paths() {
+  # Add .goalkit/ prefix to paths that don't already have .goalkit/ prefix
+  # This is sed with basic regex - avoid duplicating when .goalkit/ is already there
   sed -E \
-    -e 's@(/?)memory/@.goalkit/memory/@g' \
-    -e 's@(/?)scripts/@.goalkit/scripts/@g' \
-    -e 's@(/?)templates/@.goalkit/templates/@g'
-}
+    -e 's@(^|[^.])memory/@\1.goalkit/memory/@g' \
+    -e 's@(^|[^.])scripts/@\1.goalkit/scripts/@g' \
+    -e 's@(^|[^.])templates/@\1.goalkit/templates/@g'
+} with proper logic
 
 generate_commands() {
   local agent=$1 ext=$2 arg_format=$3 output_dir=$4 script_variant=$5
@@ -77,7 +79,7 @@ generate_commands() {
     fi
     
     # Remove the scripts: and agent_scripts: sections from frontmatter while preserving YAML structure
-    body=$(printf '%s\n' "$body" | awk '
+    body=$(printf '%s\n' "$file_content" | awk '
       /^---$/ { print; if (++dash_count == 1) in_frontmatter=1; else in_frontmatter=0; next }
       in_frontmatter && /^scripts:$/ { skip_scripts=1; next }
       in_frontmatter && /^agent_scripts:$/ { skip_scripts=1; next }
@@ -86,8 +88,19 @@ generate_commands() {
       { print }
     ')
     
-    # Apply other substitutions
-    body=$(printf '%s\n' "$body" | sed "s|{ARGS}|$arg_format|g" | sed "s/__AGENT__/$agent/g" | rewrite_paths)
+    # Apply path rewrites to template paths FIRST, before replacing {SCRIPT} to avoid duplicating .goalkit/
+    body=$(printf '%s\n' "$body" | rewrite_paths)
+    
+    # Replace {SCRIPT} placeholder with the script command after path rewrites
+    body=$(printf '%s\n' "$body" | sed "s|{SCRIPT}|${script_command}|g")
+    
+    # Replace {AGENT_SCRIPT} placeholder with the agent script command if found
+    if [[ -n $agent_script_command ]]; then
+      body=$(printf '%s\n' "$body" | sed "s|{AGENT_SCRIPT}|${agent_script_command}|g")
+    fi
+    
+    # Apply other substitutions last
+    body=$(printf '%s\n' "$body" | sed "s|{ARGS}|$arg_format|g" | sed "s/__AGENT__/$agent/g")
 
     case $ext in
       toml)


### PR DESCRIPTION
Prevent duplication of .goalkit/ prefix in paths by updating sed regex patterns. Apply path rewrites before placeholder replacements to ensure correct script generation order. Fix variable reference from $body to $file_content in awk command for accurate frontmatter processing.