### PR TITLE
fix(ci): correct syntax error in release package script

### DIFF
--- a/.github/workflows/scripts/create-release-packages.sh
+++ b/.github/workflows/scripts/create-release-packages.sh
@@ -37,7 +37,7 @@ rewrite_paths() {
     -e 's@(^|[^.])memory/@\1.goalkit/memory/@g' \
     -e 's@(^|[^.])scripts/@\1.goalkit/scripts/@g' \
     -e 's@(^|[^.])templates/@\1.goalkit/templates/@g'
-} with proper logic
+}
 
 generate_commands() {
   local agent=$1 ext=$2 arg_format=$3 output_dir=$4 script_variant=$5


### PR DESCRIPTION
Remove erroneous text after closing brace in rewrite_paths function to fix script execution.