### PR TITLE
fix(ci): correct temp dir variable expansion

### DIFF
--- a/.github/workflows/scripts/create-release-packages.sh
+++ b/.github/workflows/scripts/create-release-packages.sh
@@ -48,7 +48,7 @@ create_temp_package_dir() {
         temp_dir=$(mktemp -d 2>/dev/null || mktemp -d -t tmp)
     else
         # Fallback for Windows/other systems
-        temp_dir="/tmp/goalkit_temp_$(date +%s)_$"
+        temp_dir="/tmp/goalkit_temp_$(date +%s)_$$"
         mkdir -p "$temp_dir"
     fi
     echo "Created temp dir for $agent-$script_type at $temp_dir" >&2


### PR DESCRIPTION
The temp directory path was using a single `$` which did not properly expand to the process ID. Changed to `$$` to ensure the shell variable is correctly interpreted as the current process ID for unique directory naming.