### PR TITLE
ci(release): add zip installation for Linux in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,9 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install zip
+        run: sudo apt-get update && sudo apt-get install -y zip
+        if: runner.os == 'Linux'
       - name: Get latest tag
         id: get_tag
         run: |


### PR DESCRIPTION
Ensure zip utility is available on Linux runners during the release job to support packaging requirements.