### PR TITLE
docs(templates): update documentation templates to clarify paths rela…

### DIFF
--- a/templates/commands/goal.md
+++ b/templates/commands/goal.md
@@ -1,9 +1,11 @@
 ---
 description: Execute the goal definition workflow by creating a new goal using the goal template to generate a goal definition.
 scripts:
+  # Paths are relative to PROJECT ROOT (not relative to .goalkit/)
   sh: .goalkit/scripts/bash/create-new-goal.sh --json "{ARGS}"
   ps: .goalkit/scripts/powershell/create-new-goal.ps1 -Json "{ARGS}"
 agent_scripts:
+  # Paths are relative to PROJECT ROOT (not relative to .goalkit/)
   sh: .goalkit/scripts/bash/update-agent-context.sh __AGENT__
   ps: .goalkit/scripts/powershell/update-agent-context.ps1 -AgentType __AGENT__
 ---
@@ -42,7 +44,7 @@ Given that goal description, do this:
    - For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\\''m Groot' (or double-quote if possible: "I'm Groot")
    - First find the git repository root by looking for `.git` directory or using git command to locate it
    - Change to the repository root directory before executing the script  
-   - Ensure the script path is resolved from the repository root (path should not contain duplicate `.goalkit/` prefixes. Scripts are in `{PROJECT_ROOT}/.goalkit/scripts/[platform]/[script-name]` )
+   - Ensure the script path is resolved from the repository root (path should not contain duplicate `.goalkit/` prefixes.)
    - Verify the script file exists at the expected path: `{PROJECT_ROOT}/.goalkit/scripts/[platform]/[script-name]` before executing
    - If the file exists at the expected path but the command fails, double-check path resolution
    - You must only ever run this script once

--- a/templates/commands/milestones.md
+++ b/templates/commands/milestones.md
@@ -1,9 +1,11 @@
 ---
 description: Create measurable milestones and progress indicators for achieving goals.
 scripts:
+  # Paths are relative to PROJECT ROOT (not relative to .goalkit/)
   sh: .goalkit/scripts/bash/setup-milestones.sh --json "{ARGS}"
   ps: .goalkit/scripts/powershell/setup-milestones.ps1 -Json "{ARGS}"
 agent_scripts:
+  # Paths are relative to PROJECT ROOT (not relative to .goalkit/)
   sh: .goalkit/scripts/bash/update-agent-context.sh __AGENT__
   ps: .goalkit/scripts/powershell/update-agent-context.ps1 -AgentType __AGENT__
 ---

--- a/templates/commands/strategies.md
+++ b/templates/commands/strategies.md
@@ -1,9 +1,11 @@
 ---
 description: Explore multiple implementation strategies for achieving goals.
 scripts:
+  # Paths are relative to PROJECT ROOT (not relative to .goalkit/)
   sh: .goalkit/scripts/bash/setup-strategy.sh --json "{ARGS}"
   ps: .goalkit/scripts/powershell/setup-strategy.ps1 -Json "{ARGS}"
 agent_scripts:
+  # Paths are relative to PROJECT ROOT (not relative to .goalkit/)
   sh: .goalkit/scripts/bash/update-agent-context.sh __AGENT__
   ps: .goalkit/scripts/powershell/update-agent-context.ps1 -AgentType __AGENT__
 ---

--- a/templates/slash-command-guide.md
+++ b/templates/slash-command-guide.md
@@ -23,54 +23,55 @@ Goal files must be created inside the appropriate goal directory:
 ### Vision Command
 - **For `/goalkit.vision`**
   1. **Generate** content for vision.md based on user's vision statement
-  2. **Create directory** `.goalkit/` (if not exists)
-  3. **Save file** as `.goalkit/vision.md`
+  2. **Create directory** `.goalkit/` (if not exists) in the PROJECT ROOT
+  3. **Save file** as `.goalkit/vision.md` in the PROJECT ROOT
   4. **Content**: Project vision, principles, and success criteria
 
 ### Goal Command
 - **For `/goalkit.goal`**
   1. **Generate** content for goal.md based on user's goal description
-  2. **Create directory** `goals/001-goal-name/` (using sequential numbering)
-  3. **Save file** as `goals/[###-goal-name]/goal.md`
+  2. **Create directory** `.goalkit/goals/001-goal-name/` (using sequential numbering) in the PROJECT ROOT
+  3. **Save file** as `.goalkit/goals/[###-goal-name]/goal.md` in the PROJECT ROOT
   4. **Directory name** format: `[###]-[url-friendly-goal-title]`
 
 ### Strategy Command
 - **For `/goalkit.strategies`**
-  1. **Determine** the appropriate goal directory
+  1. **Determine** the appropriate goal directory in `.goalkit/goals/`
   2. **Generate** content for strategies.md based on the associated goal
-  3. **Save file** as `goals/[goal-directory]/strategies.md`
+  3. **Save file** as `.goalkit/goals/[goal-directory]/strategies.md` in the PROJECT ROOT
 
 ### Milestones Command
 - **For `/goalkit.milestones`**
-  1. **Determine** the appropriate goal directory
+  1. **Determine** the appropriate goal directory in `.goalkit/goals/`
   2. **Generate** content for milestones.md based on the associated goal
-  3. **Save file** as `goals/[goal-directory]/milestones.md`
+  3. **Save file** as `.goalkit/goals/[goal-directory]/milestones.md` in the PROJECT ROOT
 
 ### Execute Command
 - **For `/goalkit.execute`**
-  1. **Determine** the appropriate goal directory
+  1. **Determine** the appropriate goal directory in `.goalkit/goals/`
   2. **Generate** content for execution.md based on the associated goal
-  3. **Save file** as `goals/[goal-directory]/execution.md`
+  3. **Save file** as `.goalkit/goals/[goal-directory]/execution.md` in the PROJECT ROOT
 
 ## File Creation Process
 When creating any goal-related file:
 
-1. **Detect project structure**: Verify `.goalkit/` directory exists
-2. **Determine goal directory**: Use existing goal or create new one in sequence
-3. **Create directory if needed**: Ensure `goals/[goal-directory]/` exists
-4. **Save file**: Create the appropriate markdown file in the correct location
+1. **Detect project structure**: Verify `.goalkit/` directory exists in the PROJECT ROOT
+2. **Determine goal directory**: Use existing goal or create new one in sequence in `.goalkit/goals/`
+3. **Create directory if needed**: Ensure `.goalkit/goals/[goal-directory]/` exists in the PROJECT ROOT
+4. **Save file**: Create the appropriate markdown file in the correct location in the PROJECT ROOT
 5. **Maintain consistency**: Ensure cross-references between files are accurate
 
 ## Context Retention Reminder
 When responding to user queries, AI agents should:
-1. Check if the query relates to known goals in `goals/`
-2. Reference the appropriate goal context from vision, goal, strategies, milestones, or execution files
+1. Check if the query relates to known goals in `.goalkit/goals/`
+2. Reference the appropriate goal context from vision, goal, strategies, milestones, or execution files in `.goalkit/`
 3. Provide responses aligned with current goal status
-4. Create new files in the proper goal-specific directories
+4. Create new files in the proper `.goalkit/goals/` directory structure
 
 ## Error Prevention
 Before file creation, ensure:
-- Project has `.goalkit/` directory (create if needed)
-- Goal directory exists or create new one with proper numbering
-- File will be saved in proper location within goal-specific directory
-- All necessary parent directories exist
+- Project has `.goalkit/` directory in the PROJECT ROOT (create if needed)
+- Goal directory exists in `.goalkit/goals/` or create new one with proper numbering
+- File will be saved in proper location within `.goalkit/goals/` directory structure
+- All necessary parent directories exist in the PROJECT ROOT
+- Avoid creating double-prefixed directories like `.goalkit.goalkit/` - always use `.goalkit/` in the PROJECT ROOT


### PR DESCRIPTION
…tive to project root

Clarified path references in command templates and slash-command guide to emphasize PROJECT ROOT, preventing confusion with duplicate .goalkit/ prefixes. Updated directory structures and instructions for consistency across goal-related files.