### PR TITLE
refactor(cli): enforce strict workflow in agent methodology

### DIFF
--- a/src/goalkeeper_cli/__init__.py
+++ b/src/goalkeeper_cli/__init__.py
@@ -696,6 +696,31 @@ def create_agent_file(project_path: Path, ai_assistant: str):
     content = content.replace("[EXTRACTED FROM EXECUTION.MD]", "No execution plans yet. Use /goalkit.execute after creating milestones.")
     content = content.replace("[LAST 3 COMPLETED MILESTONES AND OUTCOMES]", "No completed milestones yet.")
 
+    # Add strict workflow enforcement to agent files
+    # Insert after the "## 🔧 Next Recommended Actions" section
+    workflow_enforcement = """
+
+## 🚨 STRICT WORKFLOW ENFORCEMENT
+
+**🛑 STOP AFTER EACH COMMAND - ONE AT A TIME**
+
+**FORBIDDEN AGENT BEHAVIORS:**
+- ❌ Creating goals automatically after vision
+- ❌ Starting coding after vision creation
+- ❌ Chaining commands without user input
+- ❌ Skipping methodology steps
+
+**ALLOWED SEQUENCE:**
+- `/goalkit.vision` → Create vision → **🛑 STOP**
+- User runs `/goalkit.goal` → Create goal → **🛑 STOP**
+- User runs `/goalkit.strategies` → Explore strategies → **🛑 STOP**
+- User runs `/goalkit.milestones` → Create milestones → **🛑 STOP**
+- User runs `/goalkit.execute` → Implement → Continue
+"""
+    # Insert the workflow enforcement before the end of the file
+    content = content.replace("*This guide is automatically created by goalkeeper init. It provides essential guidance for agents working on this Goal Kit project.*",
+                             workflow_enforcement + "\n*This guide is automatically created by goalkeeper init. It provides essential guidance for agents working on this Goal Kit project.*")
+
     # Define agent-specific file names and locations
     agent_file_locations = {
         "claude": [".claude/goal-kit-guide.md"],
@@ -795,6 +820,15 @@ def create_agent_context_file(project_path: Path, ai_assistant: str):
 
 **YOU MUST FOLLOW THESE RULES EXACTLY:**
 
+### 🚨 STRICT WORKFLOW ENFORCEMENT - ONE COMMAND AT A TIME
+**🛑 STOP AFTER EACH COMMAND - WAIT FOR USER**
+
+1. **`/goalkit.vision`** → Create vision file → **🛑 STOP**
+2. **User runs** `/goalkit.goal`** → Create goal → **🛑 STOP**
+3. **User runs** `/goalkit.strategies`** → Explore strategies → **🛑 STOP**
+4. **User runs** `/goalkit.milestones`** → Create milestones → **🛑 STOP**
+5. **User runs** `/goalkit.execute`** → Implement with learning → **Continue**
+
 ### Core Methodology Rules
 1. **OUTCOMES FIRST**: Always focus on measurable user/business outcomes, NOT implementation details
 2. **NO IMPLEMENTATION DETAILS IN GOALS**: Never put languages, frameworks, APIs, or methods in goal definitions
@@ -809,6 +843,18 @@ def create_agent_context_file(project_path: Path, ai_assistant: str):
 - **/goalkit.strategies**: Explore 3+ different approaches to achieve goals
 - **/goalkit.milestones**: Create measurable progress checkpoints
 - **/goalkit.execute**: Implement with learning loops and measurement
+
+### 🚨 FORBIDDEN AGENT BEHAVIORS
+**❌ STOP: DO NOT chain commands automatically**
+- ❌ Running `/goalkit.goal` after `/goalkit.vision` without user input
+- ❌ Starting coding or implementation after vision creation
+- ❌ Skipping any methodology steps
+- ❌ Proceeding without explicit user commands
+
+**✅ ALLOWED: Only these specific actions**
+- ✅ Creating vision file after `/goalkit.vision` → **🛑 STOP**
+- ✅ Creating goal files after `/goalkit.goal` → **🛑 STOP**
+- ✅ Starting implementation after `/goalkit.execute` → Continue
 
 ### ⚠️ CRITICAL ANTI-PATTERNS TO AVOID
 - ✗ Implementing features directly without following methodology
@@ -845,10 +891,13 @@ Remember these core principles:
 
 ## 🔧 Next Recommended Actions
 
-1. Use /goalkit.vision to establish project vision
-2. Use /goalkit.goal to define first goal
-3. Use /goalkit.strategies to explore implementation approaches
-4. Use /goalkit.milestones to plan measurable progress steps
+**🚨 STRICT WORKFLOW: Run one command at a time**
+
+1. **First**: Use /goalkit.vision to establish project vision → **🛑 STOP**
+2. **Then wait**: User runs /goalkit.goal to define first goal → **🛑 STOP**
+3. **Then wait**: User runs /goalkit.strategies to explore approaches → **🛑 STOP**
+4. **Then wait**: User runs /goalkit.milestones to plan milestones → **🛑 STOP**
+5. **Finally**: User runs /goalkit.execute to implement → Continue
 
 ## Agent Development Guidelines
 When working with Python scripts and code in this project, AI agents should follow these critical guidelines to avoid common mistakes:
@@ -1536,13 +1585,13 @@ def init(
         steps_lines.append(f"{step_num}. Set [cyan]CODEX_HOME[/cyan] environment variable before running Codex: [cyan]{cmd}[/cyan]")
         step_num += 1
 
-    steps_lines.append(f"{step_num}. Start using slash commands with your AI agent:")
+    steps_lines.append(f"{step_num}. Start using slash commands with your AI agent (ONE AT A TIME):")
 
-    steps_lines.append("   2.1 [cyan]/goalkit.vision[/] - Establish project vision and principles")
-    steps_lines.append("   2.2 [cyan]/goalkit.goal[/] - Define goals and success criteria")
-    steps_lines.append("   2.3 [cyan]/goalkit.strategies[/] - Explore implementation strategies")
-    steps_lines.append("   2.4 [cyan]/goalkit.milestones[/] - Create measurable milestones")
-    steps_lines.append("   2.5 [cyan]/goalkit.execute[/] - Execute with learning and adaptation")
+    steps_lines.append("   🚨 [cyan]/goalkit.vision[/] - Establish project vision → [red]🛑 STOP[/]")
+    steps_lines.append("   ⏳ Wait for user to run: [cyan]/goalkit.goal[/] - Define goals → [red]🛑 STOP[/]")
+    steps_lines.append("   ⏳ Wait for user to run: [cyan]/goalkit.strategies[/] - Explore strategies → [red]🛑 STOP[/]")
+    steps_lines.append("   ⏳ Wait for user to run: [cyan]/goalkit.milestones[/] - Create milestones → [red]🛑 STOP[/]")
+    steps_lines.append("   ⏳ Wait for user to run: [cyan]/goalkit.execute[/] - Execute with learning → Continue")
 
     steps_panel = Panel("\n".join(steps_lines), title="Next Steps", border_style="cyan", padding=(1,2))
     console.print()

--- a/templates/agent-file-template.md
+++ b/templates/agent-file-template.md
@@ -4,12 +4,19 @@
 
 ## 🎯 Goal-Driven Methodology
 
-### **CRITICAL: Always follow this 5-step sequence:**
-1. **`/goalkit.vision`** - Establish project vision and principles
-2. **`/goalkit.goal`** - Define goals with measurable outcomes
-3. **`/goalkit.strategies`** - Explore multiple implementation approaches
-4. **`/goalkit.milestones`** - Create measurable progress checkpoints
-5. **`/goalkit.execute`** - Implement with learning and adaptation
+### **🚨 CRITICAL: Always follow this 5-step sequence - ONE COMMAND AT A TIME:**
+
+**🛑 AGENTS MUST STOP AFTER EACH COMMAND - WAIT FOR USER**
+
+1. **`/goalkit.vision`** - Establish project vision and principles → **🛑 STOP**
+2. **User runs** `/goalkit.goal`** - Define goals with measurable outcomes → **🛑 STOP**
+3. **User runs** `/goalkit.strategies`** - Explore multiple implementation approaches → **🛑 STOP**
+4. **User runs** `/goalkit.milestones`** - Create measurable progress checkpoints → **🛑 STOP**
+5. **User runs** `/goalkit.execute`** - Implement with learning and adaptation → **🛑 STOP**
+
+**❌ FORBIDDEN: DO NOT chain commands automatically**
+**❌ FORBIDDEN: DO NOT proceed to coding after vision**
+**❌ FORBIDDEN: DO NOT skip steps in the sequence**
 
 ### **Simple Tasks vs Complex Goals**
 - **Simple tasks** (direct implementation): "fix styling", "update header", "add margin"
@@ -105,6 +112,12 @@
 
 ## 💡 Agent Best Practices
 
+### **🚨 CRITICAL Workflow Enforcement:**
+- **🛑 STOP after each command** - Never chain commands automatically
+- **Wait for user input** - Only proceed when user runs next command explicitly
+- **One command at a time** - Complete full methodology sequence step by step
+- **No automatic progression** - User must trigger each methodology step
+
 ### **Python Script Development:**
 - **Validate syntax**: `python -m py_compile script_name.py` before changes
 - **Check git status**: `git status`, `git diff` before modifying
@@ -116,6 +129,31 @@
 - **Follow sequence** - don't skip methodology steps
 - **Focus on outcomes** - not implementation details
 - **Document learnings** - capture insights throughout process
+- **🛑 STOP after completion** - Wait for user's next command
+
+### **🚨 FORBIDDEN AGENT BEHAVIORS - DO NOT DO THESE:**
+
+**❌ STOP: Chaining commands automatically**
+- ❌ Running `/goalkit.goal` after `/goalkit.vision` without user input
+- ❌ Running `/goalkit.strategies` after `/goalkit.goal` automatically
+- ❌ Proceeding through multiple methodology steps in one response
+
+**❌ STOP: Starting implementation too early**
+- ❌ Creating files or code after vision creation
+- ❌ Starting coding without completing full methodology sequence
+- ❌ Implementing features before defining goals and strategies
+
+**❌ STOP: Bypassing methodology steps**
+- ❌ Skipping the goal creation step
+- ❌ Skipping strategy exploration phase
+- ❌ Moving directly from vision to execution
+
+**✅ ALLOWED: Only these specific actions**
+- ✅ Creating vision file after `/goalkit.vision` → **STOP**
+- ✅ Creating goal files after `/goalkit.goal` → **STOP**
+- ✅ Creating strategy files after `/goalkit.strategies` → **STOP**
+- ✅ Creating milestone files after `/goalkit.milestones` → **STOP**
+- ✅ Starting implementation after `/goalkit.execute` → **Continue with learning**
 
 ### **Common Pitfalls to Avoid:**
 - ❌ Skipping strategy exploration

--- a/templates/commands/execute.md
+++ b/templates/commands/execute.md
@@ -245,4 +245,5 @@ When processing `/goalkit.execute` commands, AI agents should:
 - Implement with continuous measurement and validation
 - Establish clear feedback loops for adjustment
 - Document insights and knowledge gained throughout execution
-- **CRITICAL**: After execution begins, continue with adaptation based on results and learning
+- **START**: After `/goalkit.execute`, you may begin implementation with learning loops
+- **CONTINUE**: This is the only command where ongoing work is allowed

--- a/templates/commands/goal.md
+++ b/templates/commands/goal.md
@@ -44,6 +44,9 @@ cd "{PROJECT_ROOT}"
 - `/goalkit.milestones` - Create measurable progress checkpoints
 - `/goalkit.execute` - Implement with learning and adaptation
 
+**🛑 STOP HERE** - Do NOT proceed to strategies or implementation automatically
+**🛑 STOP HERE** - Wait for user to explicitly run `/goalkit.strategies`
+
 ## Critical Rules
 
 ✅ **DO**: Focus on measurable outcomes, not implementation details

--- a/templates/commands/milestones.md
+++ b/templates/commands/milestones.md
@@ -43,6 +43,9 @@ agent_scripts:
 **STEP 6**: Report completion and remind user of next step:
 - `/goalkit.execute` - Implement with learning and adaptation
 
+**🛑 STOP HERE** - Do NOT proceed to execution automatically
+**🛑 STOP HERE** - Wait for user to explicitly run `/goalkit.execute`
+
 ## Critical Milestone Rules
 
 ✅ **DO**: Focus on learning and validation, not just activities

--- a/templates/commands/strategies.md
+++ b/templates/commands/strategies.md
@@ -42,6 +42,9 @@ agent_scripts:
 - `/goalkit.milestones` - Create measurable progress checkpoints
 - `/goalkit.execute` - Implement with learning and adaptation
 
+**🛑 STOP HERE** - Do NOT proceed to milestones or implementation automatically
+**🛑 STOP HERE** - Wait for user to explicitly run `/goalkit.milestones`
+
 ## Critical Strategy Rules
 
 ✅ **DO**: Explore multiple valid approaches (3-4 options minimum)

--- a/templates/commands/vision.md
+++ b/templates/commands/vision.md
@@ -56,17 +56,39 @@ The command generates:
 - Project structure optimized for goal-driven development
 - Foundation for all subsequent goal definitions
 
-### Agent File Creation Instructions
+### ⚠️ CRITICAL: Agent Behavior Instructions
+
+**🚨 AGENTS MUST STOP AFTER VISION CREATION - DO NOT PROCEED TO CODING**
 
 When processing `/goalkit.vision` commands, AI agents should:
-1. Create or update the `.goalkit/vision.md` file in the project root
-2. Use the current date in YYYY-MM-DD format for the "Created" field
-3. Write the complete vision document using the template structure below
-4. After creating the vision file, inform the user that the vision has been established and suggest creating the first goal using `/goalkit.goal`
+
+1. **Create ONLY the vision file** - Create or update the `.goalkit/vision.md` file in the project root
+2. **Use current date** in YYYY-MM-DD format for the "Created" field
+3. **Write complete vision document** using the template structure below
+4. **🛑 STOP HERE** - Do NOT create goals, strategies, milestones, or start coding
+5. **🛑 STOP HERE** - Do NOT proceed to implementation or file creation
+6. **Inform user** that vision is established and suggest next step: `/goalkit.goal`
+7. **🛑 STOP HERE** - Wait for user to explicitly run the next command
+
+### 🚨 STRICT WORKFLOW ENFORCEMENT
+
+**Agents MUST follow this exact sequence:**
+- `/goalkit.vision` → Create vision file → **STOP**
+- **User runs** `/goalkit.goal` → Create goal → **STOP**
+- **User runs** `/goalkit.strategies` → Explore strategies → **STOP**
+- **User runs** `/goalkit.milestones` → Create milestones → **STOP**
+- **User runs** `/goalkit.execute` → Implement with learning → **STOP**
+
+**❌ FORBIDDEN AGENT BEHAVIOR:**
+- ❌ Creating goals automatically after vision
+- ❌ Starting coding or implementation after vision
+- ❌ Skipping the goal creation step
+- ❌ Proceeding through multiple methodology steps automatically
 
 ### File Creation Process
-- **Create/Update File**: `.goalkit/vision.md` with the vision content
+- **Create ONLY**: `.goalkit/vision.md` with the vision content
 - **Template**: Use the structure provided in the "Vision Components" section below
+- **🛑 THEN STOP**
 
 ## Vision Components
 


### PR DESCRIPTION
Add strict workflow enforcement across CLI and template files to prevent agents from chaining commands automatically. Ensures agents stop after each methodology step and wait for explicit user input, improving adherence to the goal-driven process.

- Updated src/goalkeeper_cli/__init__.py with workflow enforcement sections
- Modified command templates (vision.md, goal.md, strategies.md, milestones.md, execute.md) to include stop instructions
- Enhanced agent-file-template.md with forbidden behaviors and allowed sequences