### PR TITLE
refactor(goal): update directory paths to use .goalkit/goals

### DIFF
--- a/scripts/python/create_new_goal.py
+++ b/scripts/python/create_new_goal.py
@@ -54,7 +54,7 @@ def create_goal(goal_description, dry_run=False, force=False, json_mode=False, v
     if json_mode:
         # Find the next goal number
         next_number = 1
-        goals_dir = os.path.join(project_root, "goals")
+        goals_dir = os.path.join(project_root, ".goalkit", "goals")
         
         if os.path.exists(goals_dir):
             goal_dirs = [d for d in os.listdir(goals_dir) 
@@ -72,7 +72,7 @@ def create_goal(goal_description, dry_run=False, force=False, json_mode=False, v
         clean_description = re.sub(r'[^a-zA-Z0-9\s-]', '', goal_description)
         clean_description = re.sub(r'\s+', '-', clean_description).strip('-').lower()
         goal_dir_name = f"{goal_number}-{clean_description}"
-        goal_dir = os.path.join("goals", goal_dir_name)
+        goal_dir = os.path.join(".goalkit", "goals", goal_dir_name)
         goal_file = os.path.join(goal_dir, "goal.md")
 
         # Output JSON with required variables
@@ -87,7 +87,7 @@ def create_goal(goal_description, dry_run=False, force=False, json_mode=False, v
         return
 
     # Check if goals directory exists
-    goals_dir = os.path.join(project_root, "goals")
+    goals_dir = os.path.join(project_root, ".goalkit", "goals")
     if not os.path.exists(goals_dir):
         if dry_run:
             write_info(f"[DRY RUN] Would create goals directory: {goals_dir}")
@@ -113,7 +113,7 @@ def create_goal(goal_description, dry_run=False, force=False, json_mode=False, v
     clean_description = re.sub(r'[^a-zA-Z0-9\s-]', '', goal_description)
     clean_description = re.sub(r'\s+', '-', clean_description).strip('-').lower()
     goal_dir_name = f"{goal_number}-{clean_description}"
-    goal_dir = os.path.join("goals", goal_dir_name)
+    goal_dir = os.path.join(".goalkit", "goals", goal_dir_name)
 
     # Check if goal directory already exists
     full_goal_dir = os.path.join(project_root, goal_dir)

--- a/src/goalkeeper_cli/__init__.py
+++ b/src/goalkeeper_cli/__init__.py
@@ -891,13 +891,10 @@ Remember these core principles:
 
 ## 🔧 Next Recommended Actions
 
-**🚨 STRICT WORKFLOW: Run one command at a time**
-
-1. **First**: Use /goalkit.vision to establish project vision → **🛑 STOP**
-2. **Then wait**: User runs /goalkit.goal to define first goal → **🛑 STOP**
-3. **Then wait**: User runs /goalkit.strategies to explore approaches → **🛑 STOP**
-4. **Then wait**: User runs /goalkit.milestones to plan milestones → **🛑 STOP**
-5. **Finally**: User runs /goalkit.execute to implement → Continue
+1. Use /goalkit.vision to establish project vision
+2. Use /goalkit.goal to define first goal
+3. Use /goalkit.strategies to explore implementation approaches
+4. Use /goalkit.milestones to plan measurable progress steps
 
 ## Agent Development Guidelines
 When working with Python scripts and code in this project, AI agents should follow these critical guidelines to avoid common mistakes:
@@ -1585,13 +1582,13 @@ def init(
         steps_lines.append(f"{step_num}. Set [cyan]CODEX_HOME[/cyan] environment variable before running Codex: [cyan]{cmd}[/cyan]")
         step_num += 1
 
-    steps_lines.append(f"{step_num}. Start using slash commands with your AI agent (ONE AT A TIME):")
+    steps_lines.append(f"{step_num}. Start using slash commands with your AI agent:")
 
-    steps_lines.append("   🚨 [cyan]/goalkit.vision[/] - Establish project vision → [red]🛑 STOP[/]")
-    steps_lines.append("   ⏳ Wait for user to run: [cyan]/goalkit.goal[/] - Define goals → [red]🛑 STOP[/]")
-    steps_lines.append("   ⏳ Wait for user to run: [cyan]/goalkit.strategies[/] - Explore strategies → [red]🛑 STOP[/]")
-    steps_lines.append("   ⏳ Wait for user to run: [cyan]/goalkit.milestones[/] - Create milestones → [red]🛑 STOP[/]")
-    steps_lines.append("   ⏳ Wait for user to run: [cyan]/goalkit.execute[/] - Execute with learning → Continue")
+    steps_lines.append("   [cyan]/goalkit.vision[/] - Establish project vision and principles")
+    steps_lines.append("   [cyan]/goalkit.goal[/] - Define goals and success criteria")
+    steps_lines.append("   [cyan]/goalkit.strategies[/] - Explore implementation strategies")
+    steps_lines.append("   [cyan]/goalkit.milestones[/] - Create measurable milestones")
+    steps_lines.append("   [cyan]/goalkit.execute[/] - Execute with learning and adaptation")
 
     steps_panel = Panel("\n".join(steps_lines), title="Next Steps", border_style="cyan", padding=(1,2))
     console.print()

--- a/templates/agent-file-template.md
+++ b/templates/agent-file-template.md
@@ -65,7 +65,7 @@
 [EXTRACTED FROM ALL GOAL.MD FILES]
 
 ## 📊 Project Status
-- **Goals Created**: [Number of goals in goals/ directory]
+- **Goals Created**: [Number of goals in .goalkit/goals/ directory]
 - **Strategies Defined**: [Number of strategy files]
 - **Milestones Set**: [Number of milestone files]
 - **Current Branch**: [Current git branch]

--- a/templates/commands/execute.md
+++ b/templates/commands/execute.md
@@ -8,7 +8,7 @@ agent_scripts:
 ## Quick Prerequisites Check
 
 **BEFORE EXECUTING**:
-1. **Goal exists**: Check `goals/` directory for goal files
+1. **Goal exists**: Check `.goalkit/goals/` directory for goal files
 2. **Strategies defined**: Verify `strategies.md` in goal directory
 3. **Milestones created**: Verify `milestones.md` in goal directory
 
@@ -87,7 +87,7 @@ Use `/goalkit.execute` when:
 ## Output
 
 The command generates:
-- `goals/[###-goal-name]/execution.md` - Adaptive execution guide
+- `.goalkit/goals/[###-goal-name]/execution.md` - Adaptive execution guide
 - Measurement framework for tracking progress
 - Learning capture system for insights
 - Adaptation framework for strategy changes
@@ -95,7 +95,7 @@ The command generates:
 ### Agent File Creation Instructions
 
 When processing `/goalkit.execute` commands, AI agents should:
-1. Locate the appropriate goal directory in the `goals/` folder (the most recently created or specified goal)
+1. Locate the appropriate goal directory in the `.goalkit/goals/` folder (the most recently created or specified goal)
 2. Create the `execution.md` file inside that goal directory
 3. Use the current date in YYYY-MM-DD format for the "Date" field
 4. Write the complete execution plan using the template structure below
@@ -103,8 +103,8 @@ When processing `/goalkit.execute` commands, AI agents should:
 6. After creating the execution file, inform the user that the execution plan has been completed and suggest beginning implementation
 
 ### File Creation Process
-- **Locate Directory**: `goals/[###-goal-name]/` (most recent goal or specified goal)
-- **Create File**: `goals/[###-goal-name]/execution.md` with the execution content
+- **Locate Directory**: `.goalkit/goals/[###-goal-name]/` (most recent goal or specified goal)
+- **Create File**: `.goalkit/goals/[###-goal-name]/execution.md` with the execution content
 - **Template**: Use the structure provided in the "Execution Components" section below
 
 ## Execution Components

--- a/templates/commands/goal.md
+++ b/templates/commands/goal.md
@@ -26,7 +26,7 @@ cd "{PROJECT_ROOT}"
 - Methodology compliance
 
 **STEP 2**: Parse the JSON output to get:
-- `GOAL_DIR`: Where the goal files are created
+- `GOAL_DIR`: Where the goal files are created (in `.goalkit/goals/`)
 - `BRANCH_NAME`: The git branch for this goal
 - `GOAL_FILE`: Path to the main goal.md file
 

--- a/templates/commands/milestones.md
+++ b/templates/commands/milestones.md
@@ -11,7 +11,7 @@ agent_scripts:
 ## Quick Prerequisites Check
 
 **BEFORE CREATING MILESTONES**:
-1. **Goal exists**: Check `goals/` directory for goal files
+1. **Goal exists**: Check `.goalkit/goals/` directory for goal files
 2. **Strategies defined**: Verify `strategies.md` in goal directory
 
 **If missing**: Tell user to use `/goalkit.goal` and `/goalkit.strategies` first.
@@ -103,7 +103,7 @@ Focus on learning at each step and measurable progress indicators.
 ## Output
 
 The command generates:
-- `goals/[###-goal-name]/milestones.md` - Comprehensive milestone plan
+- `.goalkit/goals/[###-goal-name]/milestones.md` - Comprehensive milestone plan
 - Measurement framework for tracking progress
 - Learning objectives for each milestone
 - Foundation for adaptive execution
@@ -111,7 +111,7 @@ The command generates:
 ### Agent File Creation Instructions
 
 When processing `/goalkit.milestones` commands, AI agents should:
-1. Locate the appropriate goal directory in the `goals/` folder (the most recently created or specified goal)
+1. Locate the appropriate goal directory in the `.goalkit/goals/` folder (the most recently created or specified goal)
 2. Create the `milestones.md` file inside that goal directory
 3. Use the current date in YYYY-MM-DD format for the "Date" field
 4. Write the complete milestone plan using the template structure below
@@ -119,8 +119,8 @@ When processing `/goalkit.milestones` commands, AI agents should:
 6. After creating the milestones file, inform the user that the milestone plan has been completed and suggest next steps using `/goalkit.execute`
 
 ### File Creation Process
-- **Locate Directory**: `goals/[###-goal-name]/` (most recent goal or specified goal)
-- **Create File**: `goals/[###-goal-name]/milestones.md` with the milestone content
+- **Locate Directory**: `.goalkit/goals/[###-goal-name]/` (most recent goal or specified goal)
+- **Create File**: `.goalkit/goals/[###-goal-name]/milestones.md` with the milestone content
 - **Template**: Use the structure provided in the "Milestone Components" section below
 
 ## Milestone Components

--- a/templates/commands/strategies.md
+++ b/templates/commands/strategies.md
@@ -11,7 +11,7 @@ agent_scripts:
 ## Quick Prerequisites Check
 
 **BEFORE EXPLORING STRATEGIES**:
-1. **Goal exists**: Check `goals/` directory for goal files
+1. **Goal exists**: Check `.goalkit/goals/` directory for goal files
 2. **Goal is well-defined**: Verify goal has clear success metrics
 
 **If missing**: Tell user to use `/goalkit.goal` first.


### PR DESCRIPTION
Changed all references from "goals" to ".goalkit/goals" across scripts, CLI, and templates to organize project structure under a hidden directory. This refactoring improves project organization without altering functionality.

Simplified workflow instructions in CLI to remove strict enforcement markers, making the process more flexible while maintaining core guidance.